### PR TITLE
Alpha search improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,7 +81,7 @@ dependencies = [
 
 [[package]]
 name = "color_bruteforcer"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "palette 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -133,17 +133,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fuchsia-zircon"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "fuchsia-zircon-sys"
-version = "0.3.3"
+name = "fuchsia-cprng"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -223,7 +214,7 @@ name = "palette_derive"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -276,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -295,7 +286,7 @@ name = "quote"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -309,8 +300,8 @@ dependencies = [
  "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_jitter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "rand_jitter"
-version = "0.1.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -366,13 +357,13 @@ dependencies = [
 
 [[package]]
 name = "rand_os"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -510,7 +501,7 @@ name = "syn"
 version = "0.14.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -622,8 +613,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3be565ca5c557d7f59e7cfcf1844f9e3033650c929c6566f511e8005f205c1d0"
 "checksum encode_unicode 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "28d65f1f5841ef7c6792861294b72beda34c664deb8be27970f36c306b7da1ce"
-"checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
-"checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
+"checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)" = "e962c7641008ac010fa60a7dfdc1712449f29c44ef2d4702394aea943ee75047"
@@ -640,7 +630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_codegen 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "b03e85129e324ad4166b06b2c7491ae27fe3ec353af72e72cd1654c7225d517e"
 "checksum phf_generator 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "09364cc93c159b8b06b1f4dd8a4398984503483891b0c26b867cf431fb132662"
 "checksum phf_shared 0.7.24 (registry+https://github.com/rust-lang/crates.io-index)" = "234f71a15de2288bcb7e3b6515828d22af7ec8598ee6d24c3b526fa0a80b67a0"
-"checksum proc-macro2 0.4.26 (registry+https://github.com/rust-lang/crates.io-index)" = "38fddd23d98b2144d197c0eca5705632d4fe2667d14a6be5df8934f8d74f1978"
+"checksum proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)" = "4d317f9caece796be1980837fd5cb3dfec5613ebdb04ad0956deea83ce168915"
 "checksum promptly 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "90c082526d7e3401d1cde22b0c024d9fcc2ea005610fdb5d00de6199bc2840b2"
 "checksum quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)" = "cdd8e04bd9c52e0342b406469d494fcb033be4bdbe5c606016defbb1681411e1"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -649,8 +639,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum rand_hc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
 "checksum rand_isaac 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-"checksum rand_jitter 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f47842851e13bd803b506bdd1345328e0a1394733ee58e627b5e39332b9afafe"
-"checksum rand_os 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f46fbd5550acf75b0c2730f5dd1873751daf9beb8f11b44027778fae50d7feca"
+"checksum rand_jitter 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7b9ea758282efe12823e0d952ddb269d2e1897227e464919a554f2a03ef1b832"
+"checksum rand_os 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b7c690732391ae0abafced5015ffb53656abfaec61b342290e5eb56b286a679d"
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rayon 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "373814f27745b2686b350dd261bfd24576a6fb0e2c5919b3a2b6005f820b0473"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "color_bruteforcer"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["Torsten Ostgard"]
 license = "MIT"
 
@@ -15,4 +15,4 @@ palette = "0.4"
 pbr = "1.0"
 promptly = "0.1"
 rayon = "1.0"
-regex = "1.0"
+regex = "1.1"

--- a/src/lib/alpha_generator.rs
+++ b/src/lib/alpha_generator.rs
@@ -1,0 +1,184 @@
+use std::collections::HashSet;
+
+#[derive(Debug, Default)]
+pub struct AlphaGenerator {
+    alpha_min: u8,
+    alpha_max: u8,
+    previous_alpha: u8,
+    first_hit: Option<u8>,
+    guesses: Vec<u8>,
+    should_check: Vec<bool>,
+}
+
+fn generate_initial_guesses(alpha_min: u8, alpha_max: u8) -> Vec<u8> {
+    let num_alphas = alpha_max - alpha_min;
+    let mut guesses = Vec::with_capacity(usize::from(num_alphas));
+    let midpoint = num_alphas / 2 + alpha_min;
+    let mut previously_generated = HashSet::new();
+    for step_size in &[3u8, 1u8] {
+        let mut alpha = midpoint;
+        while alpha_min <= alpha && alpha <= alpha_max {
+            if !previously_generated.contains(&alpha) {
+                guesses.push(alpha)
+            }
+            previously_generated.insert(alpha);
+            let diff = i16::from(alpha) - i16::from(midpoint);
+
+            alpha = if diff <= 0 {
+                midpoint + diff.abs() as u8 + step_size
+            } else {
+                midpoint - diff as u8
+            };
+        }
+    }
+
+    // Reverse so that the values are returned by pop() in the desired order.
+    guesses.reverse();
+
+    guesses
+}
+
+impl AlphaGenerator {
+    pub fn new(alpha_min: u8, alpha_max: u8) -> Self {
+        let mut a = AlphaGenerator::default();
+        a.alpha_min = alpha_min;
+        a.alpha_max = alpha_max;
+        a.guesses = generate_initial_guesses(a.alpha_min, a.alpha_max);
+        a.should_check = vec![false; 99];
+
+        for i in a.alpha_min..=a.alpha_max {
+            let i = usize::from(i);
+            a.should_check[i - 1] = true;
+        }
+
+        a
+    }
+
+    pub fn next(&mut self, had_results: bool) -> Option<u8> {
+        if had_results && self.first_hit.is_none() {
+            self.first_hit = Some(self.previous_alpha);
+            self.guesses = self.generate_guesses_after_first_hit();
+        } else if !had_results && self.first_hit.is_some() {
+            let (_drained, kept_values) = {
+                if self.previous_alpha < self.first_hit.unwrap() {
+                    // Only keep numbers above first hit
+                    self.guesses
+                        .iter()
+                        .partition(|&&x| x < self.first_hit.unwrap())
+                } else {
+                    // Only keep numbers below first hit
+                    self.guesses
+                        .iter()
+                        .partition(|&&x| x > self.first_hit.unwrap())
+                }
+            };
+
+            self.guesses = kept_values;
+        }
+
+        let alpha = self.guesses.pop();
+
+        if alpha.is_some() {
+            self.should_check[usize::from(alpha.unwrap() - 1)] = false;
+            self.previous_alpha = alpha.unwrap();
+        }
+
+        alpha
+    }
+
+    fn generate_guesses_after_first_hit(&mut self) -> Vec<u8> {
+        let mut guesses = Vec::new();
+        let first_hit = self.first_hit.unwrap();
+        for i in (self.alpha_min..first_hit).rev() {
+            if !self.should_check[usize::from(i - 1)] {
+                break;
+            }
+
+            guesses.push(i);
+        }
+        for i in (first_hit + 1)..=self.alpha_max {
+            if !self.should_check[usize::from(i - 1)] {
+                break;
+            }
+
+            guesses.push(i);
+        }
+
+        guesses.reverse();
+
+        guesses
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn _get_range(alpha_generator: &mut AlphaGenerator, match_start: u8, match_end: u8) -> Vec<u8> {
+        let mut had_results = false;
+        let mut results = Vec::new();
+        loop {
+            let alpha = alpha_generator.next(had_results);
+
+            match alpha {
+                Some(a) => {
+                    had_results = match_start <= a && a <= match_end;
+                    results.push(a)
+                }
+                None => break,
+            }
+        }
+
+        results
+    }
+
+    #[test]
+    fn test_full_range_no_results_found() {
+        let mut alpha_generator = AlphaGenerator::new(1, 99);
+        let results = _get_range(&mut alpha_generator, 0, 0);
+        let expected_result = vec![
+            50, 53, 47, 56, 44, 59, 41, 62, 38, 65, 35, 68, 32, 71, 29, 74, 26, 77, 23, 80, 20, 83,
+            17, 86, 14, 89, 11, 92, 8, 95, 5, 98, 2, 51, 49, 52, 48, 54, 46, 55, 45, 57, 43, 58,
+            42, 60, 40, 61, 39, 63, 37, 64, 36, 66, 34, 67, 33, 69, 31, 70, 30, 72, 28, 73, 27, 75,
+            25, 76, 24, 78, 22, 79, 21, 81, 19, 82, 18, 84, 16, 85, 15, 87, 13, 88, 12, 90, 10, 91,
+            9, 93, 7, 94, 6, 96, 4, 97, 3, 99, 1,
+        ];
+        assert_eq!(expected_result, results);
+    }
+
+    #[test]
+    fn test_short_range_odd_diff_no_results_found() {
+        let mut alpha_generator = AlphaGenerator::new(75, 86);
+        let results = _get_range(&mut alpha_generator, 0, 0);
+        let expected_result = vec![80, 83, 77, 86, 81, 79, 82, 78, 84, 76, 85, 75];
+        assert_eq!(expected_result, results);
+    }
+
+    #[test]
+    fn test_short_range_even_diff_no_results_found() {
+        let mut alpha_generator = AlphaGenerator::new(75, 85);
+        let results = _get_range(&mut alpha_generator, 0, 0);
+        let expected_result = vec![80, 83, 77, 81, 79, 82, 78, 84, 76, 85, 75];
+        assert_eq!(expected_result, results);
+    }
+
+    #[test]
+    fn test_full_range_results_found() {
+        let mut alpha_generator = AlphaGenerator::new(1, 99);
+        let results = _get_range(&mut alpha_generator, 73, 77);
+        let expected_result = vec![
+            50, 53, 47, 56, 44, 59, 41, 62, 38, 65, 35, 68, 32, 71, 29, 74, 73, 72, 75, 76, 77, 78,
+        ];
+        assert_eq!(expected_result, results);
+    }
+
+    #[test]
+    fn test_matches_exist_outside_of_alpha_range() {
+        let mut alpha_generator = AlphaGenerator::new(19, 31);
+        let results = _get_range(&mut alpha_generator, 17, 21);
+        let expected_result = vec![25, 28, 22, 31, 19, 20, 21];
+        // The results should be bounded by the provided min and max alphas, so even though 17 and
+        // 18 are valid matches, they should not appear in the results.
+        assert_eq!(expected_result, results);
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -224,7 +224,7 @@ fn trim_color(color: &str) -> String {
 
 pub fn get_app() -> App<'static, 'static> {
     App::new("color_bruteforcer")
-        .version("0.1.0")
+        .version("1.1.0")
         .author("Torsten Ostgard")
         .about("Finds an unknown, semitransparent overlay color.")
         .arg(

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -14,7 +14,9 @@ use promptly::prompt;
 use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use regex::Regex;
 
+mod alpha_generator;
 mod color_distance;
+pub use self::alpha_generator::AlphaGenerator;
 
 pub const COLOR_REGEX: &str = r"^#?(([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2}))$";
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use std::process::exit;
 use pbr::ProgressBar;
 
 pub mod lib;
-use lib::{get_app, get_colors, search_alpha, ColorResult};
+use lib::{get_app, get_colors, search_alpha, AlphaGenerator, ColorResult};
 
 fn main() {
     let arg_matches = get_app().get_matches();
@@ -33,16 +33,22 @@ fn main() {
     let mut color_results = Vec::new();
     let num_alphas = u64::from((alpha_max + 1) - alpha_min);
     let mut pb = ProgressBar::new(num_alphas);
+    pb.show_counter = false;
     pb.message("Found 0 possible colors ");
+    let mut alpha_generator = AlphaGenerator::new(alpha_min, alpha_max);
+    let mut previous_alpha_had_results = false;
 
-    for alpha_int in alpha_min..=alpha_max {
+    while let Some(alpha_int) = alpha_generator.next(previous_alpha_had_results) {
         let alpha = f32::from(alpha_int) / 100.0;
         let mut alpha_results = search_alpha(&base_colors, &target_colors, alpha, max_distance);
+        previous_alpha_had_results = !alpha_results.is_empty();
         color_results.append(&mut alpha_results);
         pb.inc();
         let message = format!("Found {} possible colors ", color_results.len());
         pb.message(message.as_str());
     }
+
+    pb.finish();
 
     if color_results.is_empty() {
         println!("\n\nNo results found.");


### PR DESCRIPTION
Doing a naive linear search starting from 1% to 99% opacity is tremendously inefficient, since a significant portion of the execution time will be spent search alpha values which are very unlikely to yield results, particularly those less than 15 and greater than 85. It makes much more sense to start at the midpoint (e.g. 50), taking large steps until a match is found. Once a match has been found, the search then looks one by one at alpha values both higher and lower than the first match until no matches are found in both directions. This process should find all matches in minimal time. If somehow the large steps produce no matches, the step size changes to one and every alpha value - excluding the ones already checked - is searched, again going outward from the midpoint.

Having seen that matches tend to be found in a range of around five alpha values (e.g. alphas in the interval [28, 32] for an overlay color originally applied at 30% opacity), it seems sensible to set the large step size to 3. This value is very likely to hit even a smaller than average band of matches without checking too many values initially.